### PR TITLE
Add Purchases API in Java SDK #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,37 @@
 # nimbasms-java
-A Java module for communicating with Nimba SMS API. 
 
-## Usage
-First, instantiate the client using your API key:
+A Java module for communicating with the **Nimba SMS API**.
+
+[![](https://jitpack.io/v/nimbasms/nimbasms-java.svg)](https://jitpack.io/#nimbasms/nimbasms-java)
+
+---
+
+## Table of Contents
 
 - [Installation](#installation)
-- [Get your Access token](#accesToken)
-- [Accounts](#account)
-- [Groups](#group)
-- [Sendernames](#sendername)
-- [Contacts](#contact)
-- [Message](#message)
+- [JitPack Setup](#jitpack-setup)
+- [Credentials Setup](#credentials-setup)
+- [Usage](#usage)
+    - [Access Token](#access-token)
+    - [Accounts](#accounts)
+    - [Groups](#groups)
+    - [Sender Names](#sender-names)
+    - [Contacts](#contacts)
+    - [Messages](#messages)
+    - [Purchases](#purchases)
+
+---
+
 ## <a name="installation"></a> Installation
 
 ### System Requirements
 - JDK 11 or higher.
 - subscription via Nimba SMS Partner portal
 
+- Java 11 or higher
+- Subscription via [Nimba SMS Partner Portal](https:///www.nimbasms.com)
+
+### Maven (Default - Maven Central)
 ### Add Maven Dependency
 If you use Maven, add the following configuration to your project's `pom.xml`
 ```maven
@@ -24,6 +39,36 @@ If you use Maven, add the following configuration to your project's `pom.xml`
   <groupId>com.nimbasms</groupId>
   <artifactId>nimbasms</artifactId>
   <version>0.0.1</version>
+</dependency>
+```
+## <a name="jitpack-setup"></a> JitPack Setup
+> ⚠️ If the package is not yet on Maven Central, you can use JitPack
+
+```xml
+<repositories>
+  <repository>
+  <id>jitpack.io</id>
+  <url>https://jitpack.io</url>
+  </repository>
+</repositories>
+```
+### Add Dependency
+Using the latest release tag (recommended):
+
+```xml
+<dependency>
+    <groupId>com.github.nimbasms</groupId>
+    <artifactId>nimbasms-java</artifactId>
+    <version>v0.0.1</version> <!-- Replace with the latest tag -->
+</dependency>
+```
+If no release exists:
+
+```xml
+<dependency>
+    <groupId>com.github.nimbasms</groupId>
+    <artifactId>nimbasms-java</artifactId>
+    <version>master-SNAPSHOT</version> <!-- Or use commit hash -->
 </dependency>
 ```
 ## Configuration of Credentials
@@ -170,3 +215,33 @@ MessageDetails messageDetails = client.getMessage().retrieve("123");
 System.out.println(messageDetails);
 ```
 
+## <a name="purchase"></a> Purchases
+List all purchases
+```java
+PurchaseResponse purchases = client.getPurchase().list();
+```
+Retrieve the last 10 purchases
+```java
+PurchaseResponse last10Purchases = client.getPurchase().list(10, 1);
+```
+The next method returns the next item in a list.
+```java
+PurchaseResponse nextPurchases = client.getPurchase().next();
+```
+The previous method returns the previous item in a list.
+```java
+PurchaseResponse previousPurchases = client.getPurchase().previous();
+```
+---
+
+## License
+
+This project is licensed under the MIT License – see the [LICENSE](LICENSE) file for details.
+
+---
+
+## Author & Contributions
+
+Contributions to the official Java client for [Nimba SMS](https://nimbasms.com)
+
+> 💡 Feel free to open issues or pull requests to improve the SDK.

--- a/src/main/java/com/nimbasms/nimbasms/CodeUsage.java
+++ b/src/main/java/com/nimbasms/nimbasms/CodeUsage.java
@@ -4,9 +4,11 @@ import com.nimbasms.nimbasms.contacts.ContactResponse;
 import com.nimbasms.nimbasms.accounts.AccountResponse;
 import com.nimbasms.nimbasms.contacts.ContactDto;
 import com.nimbasms.nimbasms.groups.GroupResponse;
+import com.nimbasms.nimbasms.messages.MessageDto;
 import com.nimbasms.nimbasms.messages.MessageResponse;
 import com.nimbasms.nimbasms.messages.MessageDetailsResponse;
 
+import com.nimbasms.nimbasms.purchase.PurchaseResponse;
 import com.nimbasms.nimbasms.sendernames.SenderNameResponse;
 import java.io.IOException;
 import java.util.List;
@@ -58,13 +60,17 @@ public class CodeUsage {
 		System.out.println(contactResponseWithGroupsAndName);
 
 		//create message...
-		MessageResponse messageResponse = client.getMessage().create("Nimba API", List.of("+224XXXXXXXXX"), "Hello test");
+		MessageDto messageResponse = client.getMessage().create("Nimba API", List.of("+224XXXXXXXXX"), "Hello test");
 		System.out.println(messageResponse);
 
 		// Create Contact
 		//This contact will be added to the default contact list
 		ContactDto defaultContactResponse = client.getContact().create("+224XXXXXXXXX", null, null);
 		System.out.println(defaultContactResponse);
+
+		// fetch purchase histories
+		PurchaseResponse response = client.getPurchase().list();
+		System.out.println(response);
 
 	}
 

--- a/src/main/java/com/nimbasms/nimbasms/NimbaSMSClient.java
+++ b/src/main/java/com/nimbasms/nimbasms/NimbaSMSClient.java
@@ -4,9 +4,12 @@ import com.nimbasms.nimbasms.accounts.Account;
 import com.nimbasms.nimbasms.contacts.Contact;
 import com.nimbasms.nimbasms.groups.Group;
 import com.nimbasms.nimbasms.messages.Message;
+import com.nimbasms.nimbasms.purchase.Purchase;
 import com.nimbasms.nimbasms.sendernames.SenderName;
+import lombok.Getter;
 import okhttp3.Credentials;
 
+@Getter
 public class NimbaSMSClient {
     private final String token;
 
@@ -15,7 +18,7 @@ public class NimbaSMSClient {
     private final Group group;
     private final SenderName senderName;
     private final Message message;
-
+    private final Purchase purchase;
     public NimbaSMSClient(String serviceId, String secretToken) {
         token = Credentials.basic(serviceId, secretToken);
         account = new Account(this);
@@ -23,29 +26,6 @@ public class NimbaSMSClient {
         group = new Group(this);
         senderName = new SenderName(this);
         message = new Message(this);
-    }
-
-    public String getToken() {
-        return token;
-    }
-
-    public Account getAccount() {
-        return account;
-    }
-
-    public Contact getContact() {
-        return contact;
-    }
-
-    public Group getGroup() {
-        return group;
-    }
-
-    public SenderName getSenderName() {
-        return senderName;
-    }
-
-    public Message getMessage() {
-        return message;
+        purchase = new Purchase(this);
     }
 }

--- a/src/main/java/com/nimbasms/nimbasms/accounts/AccountResponse.java
+++ b/src/main/java/com/nimbasms/nimbasms/accounts/AccountResponse.java
@@ -1,7 +1,9 @@
 package com.nimbasms.nimbasms.accounts;
 
-import lombok.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.List;
 
 @Data

--- a/src/main/java/com/nimbasms/nimbasms/accounts/Link.java
+++ b/src/main/java/com/nimbasms/nimbasms/accounts/Link.java
@@ -1,6 +1,7 @@
 package com.nimbasms.nimbasms.accounts;
 
-import lombok.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/com/nimbasms/nimbasms/common/UriType.java
+++ b/src/main/java/com/nimbasms/nimbasms/common/UriType.java
@@ -1,19 +1,18 @@
 package com.nimbasms.nimbasms.common;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum UriType {
     ACCOUNTS("accounts"),
     CONTACTS("contacts"),
     GROUPS("groups"),
     SENDER_NAMES("sendernames"),
-    MESSAGES("messages");
+    MESSAGES("messages"),
+    PURCHASES("purchases");
 
     private final String path;
 
-    UriType(String path) {
-        this.path = path;
-    }
-
-    public String getPath() {
-        return path;
-    }
 }

--- a/src/main/java/com/nimbasms/nimbasms/messages/Message.java
+++ b/src/main/java/com/nimbasms/nimbasms/messages/Message.java
@@ -27,14 +27,14 @@ public class Message extends ApiImplBase<MessageResponse> {
         return "<Nimba.Message>";
     }
 
-    public MessageResponse create(String senderName, List<String> to, String message) throws IOException {
+    public MessageDto create(String senderName, List<String> to, String message) throws IOException {
         MessageRequest messageRequest = MessageRequest.builder()
                 .senderName(senderName)
                 .to(to)
                 .message(message)
                 .build();
 
-        return executePost(UriType.MESSAGES, messageRequest, MessageResponse.class);
+        return executePost(UriType.MESSAGES, messageRequest, MessageDto.class);
     }
 
     public MessageDetailsResponse retrieve(String messageId) throws IOException {

--- a/src/main/java/com/nimbasms/nimbasms/purchase/Purchase.java
+++ b/src/main/java/com/nimbasms/nimbasms/purchase/Purchase.java
@@ -1,0 +1,26 @@
+package com.nimbasms.nimbasms.purchase;
+
+import com.nimbasms.nimbasms.NimbaSMSClient;
+import com.nimbasms.nimbasms.common.ApiImplBase;
+import com.nimbasms.nimbasms.common.UriType;
+
+public class Purchase extends ApiImplBase<PurchaseResponse> {
+    public Purchase(NimbaSMSClient client) {
+        super(client);
+    }
+
+    @Override
+    protected UriType getUri() {
+        return UriType.PURCHASES;
+    }
+
+    @Override
+    protected Class<PurchaseResponse> getClassType() {
+        return PurchaseResponse.class;
+    }
+
+    @Override
+    public String toString() {
+        return "<Nimba.Purchase>";
+    }
+}

--- a/src/main/java/com/nimbasms/nimbasms/purchase/PurchaseHistoryDto.java
+++ b/src/main/java/com/nimbasms/nimbasms/purchase/PurchaseHistoryDto.java
@@ -1,0 +1,25 @@
+package com.nimbasms.nimbasms.purchase;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+@Getter
+@Setter
+@ToString
+public class PurchaseHistoryDto {
+    private String uid;
+    private String amount;
+    @JsonProperty("amount_currency")
+    private String amountCurrency;
+    private int quantity;
+    @JsonProperty("payment_type")
+    private String paymentType;
+    private String reference;
+    @JsonProperty("invoice_pdf")
+    private String invoicePdf;
+    @JsonProperty("purchase_at")
+    private String purchaseAt;
+}

--- a/src/main/java/com/nimbasms/nimbasms/purchase/PurchaseResponse.java
+++ b/src/main/java/com/nimbasms/nimbasms/purchase/PurchaseResponse.java
@@ -1,0 +1,6 @@
+package com.nimbasms.nimbasms.purchase;
+
+import com.nimbasms.nimbasms.common.ApiResponse;
+
+public class PurchaseResponse extends ApiResponse<PurchaseHistoryDto> {
+}


### PR DESCRIPTION
This Merge Request includes the following updates:

- Added `purchase ` feature: Introduced support for retrieving and navigating purchase history (SMS credits and services) via the API.

- Improved code clarity: Replaced wildcard imports (*) with explicit imports in several files for better readability and maintainability.

- Fixed return type for `message` sending: Corrected the incorrect return type in the message sending method.

These changes aim to improve reliability, clarity, and extend the functionality of the SDK.